### PR TITLE
monitor: Do not load plugin by default

### DIFF
--- a/monitor/src/main/defaults/xrootd.monitor.properties
+++ b/monitor/src/main/defaults/xrootd.monitor.properties
@@ -1,4 +1,3 @@
-pool.mover.xrootd.plugins=edu.uchicago.monitor
 summary=atl-prod05.slac.stanford.edu:9931:60
 detailed=atl-prod05.slac.stanford.edu:9930:60
 SITE=UNKNOWNSITE


### PR DESCRIPTION
dCache plugins should not auto-activate themselves. Doing so has
several disadvantages:
- Using dCache properties binds the plugins to specific versions
  of dCache (2.6 and 2.10 have different activation properties
  even though the xrootd plugin API is exactly the same).
- It causes problems on installations that support multiple VOs
  (since just installing the plugin activates it while it should
  only be activated for Atlas pools).
- Should dCache define default plugins to load, the declaration
  in the monitor plugin would suppress loading the defaults.
- Auto-loading a plugin without any trace of it in the site local
  dCache configuration is bound to create confusion if the
  plugin is forgotten in the plugin directory.

Besides, the plugin needs to be configured anyway (it needs at
least the SITE property), so there is really no point it not
letting the admin activate the plugin too.
