### PR TITLE
Don't claim plugins are for the xrootd door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ATLAS dCache xRootD door plugins
+ATLAS dCache xRootD plugins
 ==============================================
 
 This package currently contains three plugins:
@@ -6,18 +6,19 @@ This package currently contains three plugins:
 monitor plugin
 
 	intercepts xRootD protocol messages exchanged between
-	xRootD client and dCache xRootD door, extracts monitoring
+	xRootD client and dCache pools, extracts monitoring
 	information, packages it in xRootD standard format and sends
 	it using UDP to UCSD collector.
     
 redirector plugin
 
     enables upstream redirection. in case a file was not found at the site,
-    the client gets redirected to a configurable "upstream" redirector. 
+    the client gets redirected to a configurable "upstream" redirector. To
+    be used in xrootd doors.
     
 Name2Name plugin
     
     when a client requests a file given as a gLFN, it translates it to a PFN.
     an offical repository for this plugin is here: 
     http://git.cern.ch/pubweb/FAX.git
-    
+    To be used in xrootd doors.


### PR DESCRIPTION
The monitoring plugin isn't for the xrootd door. AFAIK the primary place to use it is in dCache pools.
